### PR TITLE
Removing dependency on metatools

### DIFF
--- a/test/shared/data/scanners/test_replaying.py
+++ b/test/shared/data/scanners/test_replaying.py
@@ -1,11 +1,23 @@
 import unittest
 
-from shared.tools.meta import sentinel
-
 from shared.data.recordset import RecordSet
 from shared.data.examples import simpleRecordSet, simpleAddition
 
 from shared.data.scanners.replaying import ReplayingElementScanner, ReplayingChunkScanner, ReplayingRecordScanner, ReplayingGroupScanner
+
+
+# taken from metatools shared.tools.meta
+def sentinel(iterable, stopValue):
+	"""A helper to make it simpler to implement sentinel values more idomatically.
+	This is a good way to replace a while True loop, removing the need for a break-on-value clause.
+
+	>>> [i for i in iter((x for x in range(5)).next, 3)]
+	[0, 1, 2]
+	>>> [i for i in sentinel(range(5), 3)]
+	[0, 1, 2]
+	"""
+	return iter((x for x in iterable).next, stopValue)
+
 
 
 class ReplayingElementScannerTestCase(unittest.TestCase):

--- a/test/shared/data/test_record.py
+++ b/test/shared/data/test_record.py
@@ -1,6 +1,8 @@
 import unittest
 
-from shared.tools.examples import simpleDataset
+# taken from metatools shared.tools.examples
+simpleListList = [range(i,i+3) for i in range(1,9,3)]
+simpleDataset = system.dataset.toDataSet(list('abc'),simpleListList)
 
 from shared.data.record import genRecordType
 


### PR DESCRIPTION
Re #2 two references to `metatools` are included. There's not a real need for that coupling beyond convenience, but if `metatools` isn't in the project then there's no reason `ligature` should fail.